### PR TITLE
KOMODO-66: Adding a component adds parent entity

### DIFF
--- a/Komodo/Core/ECS/Entities/Entity.cs
+++ b/Komodo/Core/ECS/Entities/Entity.cs
@@ -123,14 +123,6 @@ namespace Komodo.Core.ECS.Entities
                 case BehaviorComponent componentToAdd:
                     return Game.BehaviorSystem.AddComponent(componentToAdd);
                 case CameraComponent componentToAdd:
-                    if (Render2DSystem == null)
-                    {
-                        Render2DSystem = Game.CreateRender2DSystem();
-                    }
-                    if (Render3DSystem == null)
-                    {
-                        Render3DSystem = Game.CreateRender3DSystem();
-                    }
                     return Game.CameraSystem.AddComponent(componentToAdd);
                 case Drawable2DComponent componentToAdd:
                     if (Render2DSystem == null)

--- a/Komodo/Core/ECS/Systems/BehaviorSystem.cs
+++ b/Komodo/Core/ECS/Systems/BehaviorSystem.cs
@@ -195,7 +195,15 @@ namespace Komodo.Core.ECS.Systems
             {
                 _uninitializedComponents.Enqueue(componentToAdd);
             }
-            return AddBehaviorComponent(componentToAdd);
+            var parent = componentToAdd.Parent;
+            if (!Entities.ContainsKey(parent.ID))
+            {
+                return AddEntity(parent);
+            }
+            else
+            {
+                return AddBehaviorComponent(componentToAdd);
+            }
         }
 
         /// <summary>

--- a/Komodo/Core/ECS/Systems/CameraSystem.cs
+++ b/Komodo/Core/ECS/Systems/CameraSystem.cs
@@ -195,7 +195,15 @@ namespace Komodo.Core.ECS.Systems
             {
                 _uninitializedComponents.Enqueue(componentToAdd);
             }
-            return AddCameraComponent(componentToAdd);
+            var parent = componentToAdd.Parent;
+            if (!Entities.ContainsKey(parent.ID))
+            {
+                return AddEntity(parent);
+            }
+            else
+            {
+                return AddCameraComponent(componentToAdd);
+            }
         }
 
         /// <summary>

--- a/Komodo/Core/ECS/Systems/Render2DSystem.cs
+++ b/Komodo/Core/ECS/Systems/Render2DSystem.cs
@@ -225,7 +225,15 @@ namespace Komodo.Core.ECS.Systems
             {
                 _uninitializedComponents.Enqueue(componentToAdd);
             }
-            return AddDrawable2DComponent(componentToAdd);
+            var parent = componentToAdd.Parent;
+            if (!Entities.ContainsKey(parent.ID))
+            {
+                return AddEntity(parent);
+            }
+            else
+            {
+                return AddDrawable2DComponent(componentToAdd);
+            }
         }
 
         /// <summary>

--- a/Komodo/Core/ECS/Systems/Render3DSystem.cs
+++ b/Komodo/Core/ECS/Systems/Render3DSystem.cs
@@ -219,7 +219,15 @@ namespace Komodo.Core.ECS.Systems
             {
                 _uninitializedComponents.Enqueue(componentToAdd);
             }
-            return AddDrawable3DComponent(componentToAdd);
+            var parent = componentToAdd.Parent;
+            if (!Entities.ContainsKey(parent.ID))
+            {
+                return AddEntity(parent);
+            }
+            else
+            {
+                return AddDrawable3DComponent(componentToAdd);
+            }
         }
 
         /// <summary>

--- a/Komodo/Core/ECS/Systems/SoundSystem.cs
+++ b/Komodo/Core/ECS/Systems/SoundSystem.cs
@@ -200,7 +200,15 @@ namespace Komodo.Core.ECS.Systems
             {
                 _uninitializedComponents.Enqueue(componentToAdd);
             }
-            return AddSoundComponent(componentToAdd);
+            var parent = componentToAdd.Parent;
+            if (!Entities.ContainsKey(parent.ID))
+            {
+                return AddEntity(parent);
+            }
+            else
+            {
+                return AddSoundComponent(componentToAdd);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Parent entities should be attached to a system if a component is directly added to a system. This happens only if the entity does not already exist and will remove an entity from a previous system if necessary.

CLoses #66 