### PR TITLE
Make normalize only a static method

### DIFF
--- a/Komodo/Core/ECS/Components/CameraComponent.cs
+++ b/Komodo/Core/ECS/Components/CameraComponent.cs
@@ -259,15 +259,15 @@ namespace Komodo.Core.ECS.Components
                 _viewMatrix = value;
 
                 Backward = new Vector3(ViewMatrix.M13, ViewMatrix.M23, ViewMatrix.M33);
-                Backward.Normalize();
+                Backward = Vector3.Normalize(Backward);
                 Forward = -Backward;
 
                 Right = new Vector3(ViewMatrix.M11, ViewMatrix.M21, ViewMatrix.M31);
-                Right.Normalize();
+                Right = Vector3.Normalize(Right);
                 Left = -Right;
 
                 Up = Target == null ? new Vector3(ViewMatrix.M12, ViewMatrix.M22, ViewMatrix.M32) : Vector3.Cross(Vector3.Cross(Forward, Vector3.Up), Forward);
-                Up.Normalize();
+                Up = Vector3.Normalize(Up);
                 Down = -Up;
             }
         }

--- a/Komodo/Lib/Math/Vector2.cs
+++ b/Komodo/Lib/Math/Vector2.cs
@@ -95,11 +95,6 @@ namespace Komodo.Lib.Math
         {
             return X.GetHashCode() + Y.GetHashCode();
         }
-
-        public void Normalize()
-        {
-            MonoGameVector.Normalize();
-        }
         #endregion Public Member Methods
 
         #endregion Member Methods
@@ -176,8 +171,8 @@ namespace Komodo.Lib.Math
 
         public static Vector2 Normalize(Vector2 vectorToNormalize)
         {
-            vectorToNormalize.MonoGameVector.Normalize();
-            return new Vector2(vectorToNormalize.X, vectorToNormalize.Y);
+            var normalizedVector = Microsoft.Xna.Framework.Vector2.Normalize(vectorToNormalize.MonoGameVector);
+            return new Vector2(normalizedVector);
         }
 
         public static float Distance(Vector2 a, Vector2 b)

--- a/Komodo/Lib/Math/Vector3.cs
+++ b/Komodo/Lib/Math/Vector3.cs
@@ -194,11 +194,6 @@ namespace Komodo.Lib.Math
         {
             return X.GetHashCode() + Y.GetHashCode() + Z.GetHashCode();
         }
-
-        public void Normalize()
-        {
-            MonoGameVector.Normalize();
-        }
         #endregion Public Member Methods
 
         #endregion Member Methods
@@ -271,8 +266,8 @@ namespace Komodo.Lib.Math
 
         public static Vector3 Normalize(Vector3 vectorToNormalize)
         {
-            vectorToNormalize.MonoGameVector.Normalize();
-            return new Vector3(vectorToNormalize.X, vectorToNormalize.Y, vectorToNormalize.Z);
+            var normalizedVector = Microsoft.Xna.Framework.Vector3.Normalize(vectorToNormalize.MonoGameVector);
+            return new Vector3(normalizedVector);
         }
 
         public static Vector3 Transform(Vector3 vector, Matrix transform)


### PR DESCRIPTION
Because the Vector structs are readonly, the internal MonoGame vector cannot modify itself through a ref method. A static method is instead used to directly overwrite the internal MonoGame vector.

Closes #68 