### PR TITLE
KOMODO-110: Remove rotation from BoundingBox generation

### DIFF
--- a/DesktopGL/Startup.cs
+++ b/DesktopGL/Startup.cs
@@ -26,6 +26,7 @@ namespace DesktopGL
                     PhysicsSystem = physicsSytem,
                     Render2DSystem = render2DSystem,
                     Render3DSystem = render3DSystem,
+                    Rotation = new Vector3(0f, 0f, 1f)
                 };
                 player.AddComponent(new PlayerBehavior(0));
                 var cube = new Entity(Game)
@@ -35,16 +36,21 @@ namespace DesktopGL
                     Render3DSystem = render3DSystem,
                 };
                 cube.AddComponent(new CubeBehavior("models/cube"));
+                var cameraEntity = new Entity(Game)
+                {
+                    Render2DSystem = render2DSystem,
+                    Render3DSystem = render3DSystem,
+                };
                 var camera = new CameraComponent()
                 {
-                    Position = new Vector3(0, 0, 100f),
+                    Position = new Vector3(-100f, 0, 100f),
                     FarPlane = 10000000f,
                     IsPerspective = true,
                     Zoom = 1f,
                     Target = player,
                 };
-                player.AddComponent(camera);
-                player.AddComponent(new CameraBehavior(camera, 0));
+                cameraEntity.AddComponent(camera);
+                cameraEntity.AddComponent(new CameraBehavior(camera, 0));
                 camera.SetActive();
 
                 render2DSystem = Game.CreateRender2DSystem();
@@ -53,7 +59,7 @@ namespace DesktopGL
                     Render2DSystem = render2DSystem,
                 };
                 counterEntity.AddComponent(new FPSCounterBehavior());
-                var cameraEntity = new Entity(Game)
+                cameraEntity = new Entity(Game)
                 {
                     Position = new Vector3(0f, 0f, 0f),
                     Render2DSystem = render2DSystem,

--- a/Komodo/Core/ECS/Systems/PhysicsSystem.cs
+++ b/Komodo/Core/ECS/Systems/PhysicsSystem.cs
@@ -552,10 +552,6 @@ namespace Komodo.Core.ECS.Systems
                 MathHelper.Min(-box.Depth / 2f, box.Depth / 2f)
             ) + body.WorldPosition;
 
-            var rotation = body.RotationMatrix;
-            max = Vector3.Transform(max - body.WorldPosition, rotation) + body.WorldPosition;
-            min = Vector3.Transform(min - body.WorldPosition, rotation) + body.WorldPosition;
-
             return new BoundingBox(min.MonoGameVector, max.MonoGameVector);
         }
 


### PR DESCRIPTION
The physics engine for now will only support axis-aligned boxes. Adding oriented boxes is being scoped in KOMODO-111