### PR TITLE
Change region separation standard

### DIFF
--- a/Common/Behaviors/CameraBehavior.cs
+++ b/Common/Behaviors/CameraBehavior.cs
@@ -8,6 +8,8 @@ namespace Common.Behaviors
 {
     public class CameraBehavior : BehaviorComponent
     {
+        #region Public
+
         #region Constructors
         public CameraBehavior(CameraComponent camera, int playerIndex) : base()
         {
@@ -19,27 +21,15 @@ namespace Common.Behaviors
             Camera = camera;
             PanVelocity = 50f;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public CameraComponent Camera { get; set; }
         public int PlayerIndex { get; set; }
         public float PanVelocity { get; set; }
-        #endregion Public Members
-
-        #region Protected Members
-        #endregion Protected Members
-
-        #region Private Members
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override void Update(GameTime gameTime)
         {
             var cameraLeft = InputManager.GetAction("camera_left", PlayerIndex);
@@ -73,8 +63,8 @@ namespace Common.Behaviors
             );
             Camera.Move(cameraMove);
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Common/Behaviors/CubeBehavior.cs
+++ b/Common/Behaviors/CubeBehavior.cs
@@ -11,30 +11,21 @@ namespace Common.Behaviors
 {
     public class CubeBehavior : BehaviorComponent
     {
+        #region Public
+
         #region Constructors
         public CubeBehavior(string modelPath) : base()
         {
             ModelPath = modelPath;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public string ModelPath { get; protected set; }
         public Drawable3DComponent RootComponent { get; protected set; }
-        #endregion Public Members
-
-        #region Protected Members
-        private bool _createdBoxes { get; set; }
-        #endregion Protected Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
-
         public override void Initialize()
         {
             base.Initialize();
@@ -78,8 +69,16 @@ namespace Common.Behaviors
                 Parent.Scale = scale;
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
+
+        #region Protected
+
+        #region Members
+        private bool _createdBoxes { get; set; }
+        #endregion
+
+        #endregion
     }
 }

--- a/Common/Behaviors/FPSCounterBehavior.cs
+++ b/Common/Behaviors/FPSCounterBehavior.cs
@@ -8,26 +8,13 @@ namespace Common.Behaviors
 {
     public class FPSCounterBehavior : BehaviorComponent
     {
-        #region Constructors
-        #endregion Constructors
+        #region Public
 
         #region Members
-
-        #region Public Members
         public TextComponent CounterText { get; protected set;  }
-        #endregion Public Members
-
-        #region Protected Members
-        #endregion Protected Members
-
-        #region Private Members
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override void Initialize()
         {
             base.Initialize();
@@ -42,14 +29,8 @@ namespace Common.Behaviors
         {
             CounterText.Text = $"{Math.Round(Game.FramesPerSecond)} FPS";
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Protected Member Methods
-        #endregion Protected Member Methods
-
-        #region Private Member Methods
-        #endregion Private Member Methods
-
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Common/Behaviors/MoveBehavior.cs
+++ b/Common/Behaviors/MoveBehavior.cs
@@ -9,6 +9,8 @@ namespace Common.Behaviors
 {
     public class MoveBehavior : BehaviorComponent
     {
+        #region Public
+
         #region Constructors
         public MoveBehavior(int playerIndex) : base()
         {
@@ -20,28 +22,16 @@ namespace Common.Behaviors
             SprintFactor = 2f;
             Velocity = 50f;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public DynamicBodyComponent Body { get; private set; }
         public int PlayerIndex { get; set; }
         public float SprintFactor { get; set; }
         public float Velocity { get; set; }
-        #endregion Public Members
-
-        #region Protected Members
-        #endregion Protected Members
-
-        #region Private Members
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override void Initialize()
         {
             base.Initialize();
@@ -106,8 +96,8 @@ namespace Common.Behaviors
             //Body.Move(direction * Velocity);
             Body.ApplyForce(direction * Velocity);
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Common/Behaviors/PlayerBehavior.cs
+++ b/Common/Behaviors/PlayerBehavior.cs
@@ -9,24 +9,20 @@ namespace Common.Behaviors
 {
     public class PlayerBehavior : BehaviorComponent
     {
+        #region Public
+
         #region Constructors
         public PlayerBehavior(int playerIndex) : base()
         {
             PlayerIndex = playerIndex;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public int PlayerIndex { get; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override void Initialize()
         {
             base.Initialize();
@@ -41,8 +37,8 @@ namespace Common.Behaviors
         public override void Update(GameTime gameTime)
         {
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/BehaviorComponent.cs
+++ b/Komodo/Core/ECS/Components/BehaviorComponent.cs
@@ -8,15 +8,15 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public abstract class BehaviorComponent : Component
     {
+        #region Public
+
         #region Constructors
-        protected BehaviorComponent() : base(true, null)
+        public BehaviorComponent() : base(true, null)
         {
         }
-        #endregion Constructors
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Virtual method initializing a BehaviorComponent.
         /// </summary>
@@ -33,8 +33,8 @@ namespace Komodo.Core.ECS.Components
         /// </summary>
         /// <param name="gameTime">Time passed since last <see cref="Update"/></param>
         public abstract void Update(GameTime gameTime);
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/CameraComponent.cs
+++ b/Komodo/Core/ECS/Components/CameraComponent.cs
@@ -16,6 +16,8 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class CameraComponent : Component
     {
+        #region Public
+
         #region Constructors
         public CameraComponent() : base(true, null)
         {
@@ -29,11 +31,9 @@ namespace Komodo.Core.ECS.Components
             Rotation = Vector3.Zero;
             Zoom = 1;
         }
-        #endregion Constructors
-
+        #endregion
+        
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Backward direction for current view matrix.
         /// </summary>
@@ -289,29 +289,9 @@ namespace Komodo.Core.ECS.Components
                 ClampZoom(value);
             }
         }
-        #endregion Public Members
-
-        #region Private Members
-        private float _farPlane { get; set; }
-
-        private float _fieldOfView { get; set; }
-
-        private float _maximumZoom = float.MaxValue;
-
-        private float _minimumZoom { get; set; }
-
-        private float _nearPlane { get; set; }
-
-        private Matrix _viewMatrix { get; set; }
-
-        private float _zoom { get; set; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Checks whether or not a <see cref="Microsoft.Xna.Framework.Point"/> is contained within the <see cref="BoundingFrustum"/> of the CameraComponent.
         /// </summary>
@@ -435,9 +415,13 @@ namespace Komodo.Core.ECS.Components
         {
             ClampZoom(Zoom - deltaZoom);
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Calculates the <see cref="ViewMatrix"/> by creating a look-at Matrix.
         /// </summary>
@@ -463,9 +447,29 @@ namespace Komodo.Core.ECS.Components
                 up.MonoGameVector
             );
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+    
+        #region Private
+
+        #region Members
+        private float _farPlane { get; set; }
+
+        private float _fieldOfView { get; set; }
+
+        private float _maximumZoom = float.MaxValue;
+
+        private float _minimumZoom { get; set; }
+
+        private float _nearPlane { get; set; }
+
+        private Matrix _viewMatrix { get; set; }
+
+        private float _zoom { get; set; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Clamps <see cref="Zoom"/> between <see cref="MaximumZoom"/> and <see cref="MinimumZoom"/> based on the passed value.
         /// </summary>
@@ -480,8 +484,8 @@ namespace Komodo.Core.ECS.Components
                 MinimumZoom
             );
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/Component.cs
+++ b/Komodo/Core/ECS/Components/Component.cs
@@ -14,8 +14,10 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public abstract class Component
     {
+        #region Public
+
         #region Constructors
-        protected Component(bool isEnabled = true, Entity parent = null)
+        public Component(bool isEnabled = true, Entity parent = null)
         {
             ID = Guid.NewGuid();
             IsEnabled = isEnabled;
@@ -24,8 +26,6 @@ namespace Komodo.Core.ECS.Components
         #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Each Component maintains a reference to the <see cref="Komodo.Core.Game"/> instance.
         /// </summary>
@@ -131,8 +131,8 @@ namespace Komodo.Core.ECS.Components
                 }
             }
         }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/Drawable2DComponent.cs
+++ b/Komodo/Core/ECS/Components/Drawable2DComponent.cs
@@ -11,15 +11,15 @@ namespace Komodo.Core.ECS.Components
     /// </summary>4
     public abstract class Drawable2DComponent : Component
     {
+        #region Public
+
         #region Constructors
-        protected Drawable2DComponent(bool isEnabled = true, Entity parent = null) : base(isEnabled, parent)
+        public Drawable2DComponent(bool isEnabled = true, Entity parent = null) : base(isEnabled, parent)
         {
         }
         #endregion
-
+        
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Center point of the rendered Component.
         /// </summary>
@@ -44,8 +44,8 @@ namespace Komodo.Core.ECS.Components
         /// Width of the rendered Component.
         /// </summary>
         public abstract float Width { get; }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/Drawable3DComponent.cs
+++ b/Komodo/Core/ECS/Components/Drawable3DComponent.cs
@@ -10,6 +10,8 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class Drawable3DComponent : Component
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates a Drawable3DComponent with a given <see cref="Komodo.Core.Engine.Graphics.Model"/>.
@@ -38,11 +40,9 @@ namespace Komodo.Core.ECS.Components
             Texture = null;
             TexturePath = null;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Provides a <see cref="Microsoft.Xna.Framework.BoundingBox"/> representing the bounds of the model.
         /// </summary>
@@ -127,8 +127,8 @@ namespace Komodo.Core.ECS.Components
                 return ModelData.Width * Parent.Scale.X;
             }
         }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/DynamicBodyComponent.cs
+++ b/Komodo/Core/ECS/Components/DynamicBodyComponent.cs
@@ -11,16 +11,16 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class DynamicBodyComponent : RigidBodyComponent
     {
+        #region Public
+
         #region Constructors
         public DynamicBodyComponent(IPhysicsShape shape)
         {
             Shape = shape;
         }
-        #endregion Constructors
-
+        #endregion
+        
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Applies a force vector to the body with no regard for the point of application.
         /// </summary>
@@ -63,8 +63,8 @@ namespace Komodo.Core.ECS.Components
         {
             base.Initialize();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/KinematicBodyComponent.cs
+++ b/Komodo/Core/ECS/Components/KinematicBodyComponent.cs
@@ -11,24 +11,20 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class KinematicBodyComponent : RigidBodyComponent
     {
+        #region Public
+
         #region Constructors
         public KinematicBodyComponent(IPhysicsShape shape)
         {
             Shape = shape;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public Vector3 PositionDelta { get; internal set; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Initializes a KinematicBodyComponent.
         /// </summary>
@@ -52,8 +48,8 @@ namespace Komodo.Core.ECS.Components
             }
             PositionDelta += movement;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/PhysicsComponent.cs
+++ b/Komodo/Core/ECS/Components/PhysicsComponent.cs
@@ -10,25 +10,21 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public abstract class PhysicsComponent : Component
     {
+        #region Public
+
         #region Constructors
-        protected PhysicsComponent() : base(true, null)
+        public PhysicsComponent() : base(true, null)
         {
             Collisions = new Dictionary<Guid, Collision>();
         }
-        #endregion Constructors
+        #endregion
 
-        #region Member Methods
-
-        #region Public Member Methods
+        #region Members
         public Dictionary<Guid, Collision> Collisions { get; }
         public PhysicsSystem PhysicsSystem => Parent?.PhysicsSystem;
-        #endregion Public Member Methods
-        
-        #endregion Member Methods
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Virtual method initializing a PhysicsComponent.
         /// </summary>
@@ -39,8 +35,8 @@ namespace Komodo.Core.ECS.Components
                 IsInitialized = true;
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/RigidBodyComponent.cs
+++ b/Komodo/Core/ECS/Components/RigidBodyComponent.cs
@@ -10,16 +10,16 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public abstract class RigidBodyComponent : PhysicsComponent
     {
+        #region Public
+        
         #region Constructors
-        protected RigidBodyComponent()
+        public RigidBodyComponent()
         {
             Material = PhysicsMaterial.GetPhysicsMaterial("default");
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Rotational velocity.
         /// </summary>
@@ -72,18 +72,9 @@ namespace Komodo.Core.ECS.Components
         /// Current torque applied to the RigidBodyComponent.
         /// </summary>
         public Vector3 Torque { get; internal set; }
-        #endregion Public Members
-
-        #region Internal Members
-        internal PhysicsMaterial _material { get; set; }
-        internal IPhysicsShape _shape { get; set; }
-        #endregion Internal Members
-
-        #endregion Members
-
+        #endregion
+        
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Initializes a RigidBodyComponent.
         /// </summary>
@@ -91,8 +82,17 @@ namespace Komodo.Core.ECS.Components
         {
             base.Initialize();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Members
+        internal PhysicsMaterial _material { get; set; }
+        internal IPhysicsShape _shape { get; set; }
+        #endregion
+
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/SoundComponent.cs
+++ b/Komodo/Core/ECS/Components/SoundComponent.cs
@@ -13,6 +13,8 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class SoundComponent : Component
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates a SoundComponent with a filepath to a compiled <see cref="Microsoft.Xna.Framework.Audio.SoundEffect"/> content file.
@@ -26,21 +28,9 @@ namespace Komodo.Core.ECS.Components
             _instances = new Dictionary<Guid, SoundEffectInstance>();
             SoundPath = soundPath;
         }
-        #endregion Constructors
-
-        #region Destructor
-        /// <summary>
-        /// Stops all sound instance found in <see cref="_instances"/>.
-        /// </summary>
-        ~SoundComponent()
-        {
-            StopAll();
-        }
-        #endregion Destructor
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Raw sound data loaded from disk.
         /// </summary>
@@ -50,17 +40,9 @@ namespace Komodo.Core.ECS.Components
         /// Path of the <see cref="Microsoft.Xna.Framework.Audio.SoundEffect"/> if the SoundComponent was provided a model filepath via <see cref="SoundComponent.SoundComponent(string)"/>.
         /// </summary>
         public string SoundPath { get; }
-        #endregion Public Members
-
-        #region Internal Members
-        internal Dictionary<Guid, SoundEffectInstance> _instances { get; set;  }
-        #endregion Internal Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Changes the intensity of a valid sound instance found in <see cref="_instances"/>.
         /// </summary>
@@ -195,8 +177,26 @@ namespace Komodo.Core.ECS.Components
                 Stop(id);
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Members
+        internal Dictionary<Guid, SoundEffectInstance> _instances { get; set;  }
+        #endregion
+
+        #endregion
+
+        #region Destructor
+        /// <summary>
+        /// Stops all sound instance found in <see cref="_instances"/>.
+        /// </summary>
+        ~SoundComponent()
+        {
+            StopAll();
+        }
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/SpriteComponent.cs
+++ b/Komodo/Core/ECS/Components/SpriteComponent.cs
@@ -10,6 +10,8 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class SpriteComponent : Drawable2DComponent
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates a SpriteComponent with a given <see cref="Komodo.Core.Engine.Graphics.Texture"/>.
@@ -36,11 +38,9 @@ namespace Komodo.Core.ECS.Components
             Shader = shader;
             TexturePath = texturePath;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public override Vector2 Center => Texture != null ? new Vector2(Texture.Width / 2, Texture.Height / 2) : Vector2.Zero;
 
         /// <summary>
@@ -74,8 +74,8 @@ namespace Komodo.Core.ECS.Components
                 return Texture.Width * Parent.Scale.X;
             }
         }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/StaticBodyComponent.cs
+++ b/Komodo/Core/ECS/Components/StaticBodyComponent.cs
@@ -8,16 +8,16 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class StaticBodyComponent : RigidBodyComponent
     {
+        #region Public
+
         #region Constructors
         public StaticBodyComponent(IPhysicsShape shape)
         {
             Shape = shape;
         }
-        #endregion Constructors
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Initializes a StaticBodyComponent.
         /// </summary>
@@ -25,8 +25,8 @@ namespace Komodo.Core.ECS.Components
         {
             base.Initialize();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/TextComponent.cs
+++ b/Komodo/Core/ECS/Components/TextComponent.cs
@@ -12,6 +12,8 @@ namespace Komodo.Core.ECS.Components
     /// </summary>
     public class TextComponent : Drawable2DComponent
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates a TextComponent with a given <see cref="Microsoft.Xna.Framework.Graphics.SpriteFont"/>.
@@ -43,11 +45,9 @@ namespace Komodo.Core.ECS.Components
             Shader = shader;
             Text = text;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public override Vector2 Center => new Vector2(Width / 2, Height / 2);
 
         public Color Color { get; set; }
@@ -103,8 +103,8 @@ namespace Komodo.Core.ECS.Components
                 return size.X * Scale.X;
             }
         }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Components/TriggerBodyComponent.cs
+++ b/Komodo/Core/ECS/Components/TriggerBodyComponent.cs
@@ -10,16 +10,16 @@ namespace Komodo.Core.ECS.Components
     /// </remarks>
     public class TriggerBodyComponent : RigidBodyComponent
     {
+        #region Public
+
         #region Constructors
         public TriggerBodyComponent(IPhysicsShape shape)
         {
             Shape = shape;
         }
-        #endregion Constructors
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Initializes a TriggerBodyComponent.
         /// </summary>
@@ -27,8 +27,8 @@ namespace Komodo.Core.ECS.Components
         {
             base.Initialize();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Entities/Entity.cs
+++ b/Komodo/Core/ECS/Entities/Entity.cs
@@ -15,6 +15,8 @@ namespace Komodo.Core.ECS.Entities
     /// </summary>
     public class Entity
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public Entity([NotNull] Game game)
@@ -27,11 +29,9 @@ namespace Komodo.Core.ECS.Entities
             Rotation = Vector3.Zero;
             Scale = Vector3.One;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="Komodo.Core.ECS.Components.Component"/> objects.
         /// </summary>
@@ -91,13 +91,9 @@ namespace Komodo.Core.ECS.Entities
         /// Scaling for the entire entity. Scales all child <see cref="Komodo.Core.ECS.Components.Component"/> objects.
         /// </summary>
         public Vector3 Scale { get; set; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.Component"/> to the relevant <see cref="Komodo.Core.ECS.Systems.ISystem"/>. <see cref="AddComponent(Component)"/> will also remove the <see cref="Komodo.Core.ECS.Components.Component"/> from any Entity and <see cref="Komodo.Core.ECS.Systems.ISystem"/> it was attached to before.
         /// </summary>
@@ -243,8 +239,8 @@ namespace Komodo.Core.ECS.Entities
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/BehaviorSystem.cs
+++ b/Komodo/Core/ECS/Systems/BehaviorSystem.cs
@@ -13,6 +13,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class BehaviorSystem : ISystem<BehaviorComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public BehaviorSystem(Game game)
@@ -22,11 +24,9 @@ namespace Komodo.Core.ECS.Systems
             Game = game;
             _uninitializedComponents = new Queue<BehaviorComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects.
         /// </summary>
@@ -46,21 +46,9 @@ namespace Komodo.Core.ECS.Systems
         /// Whether or not the BehaviorSystem has called <see cref="Initialize()"/>.
         /// </summary>
         public bool IsInitialized { get; private set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<BehaviorComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the BehaviorSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -181,9 +169,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -234,7 +226,19 @@ namespace Komodo.Core.ECS.Systems
                 }
             }
         }
-        #endregion Internal Member Methods
+        #endregion
+
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<BehaviorComponent> _uninitializedComponents { get; }
+        #endregion
 
         #region Private Member Methods
         /// <summary>
@@ -277,8 +281,8 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Protected Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/CameraSystem.cs
+++ b/Komodo/Core/ECS/Systems/CameraSystem.cs
@@ -13,6 +13,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class CameraSystem : ISystem<CameraComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public CameraSystem(Game game)
@@ -22,11 +24,9 @@ namespace Komodo.Core.ECS.Systems
             Game = game;
             _uninitializedComponents = new Queue<CameraComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects.
         /// </summary>
@@ -46,21 +46,9 @@ namespace Komodo.Core.ECS.Systems
         /// Whether or not the CameraSystem has called <see cref="Initialize()"/>.
         /// </summary>
         public bool IsInitialized { get; private set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<CameraComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the CameraSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -181,9 +169,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.CameraComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.CameraComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -234,9 +226,21 @@ namespace Komodo.Core.ECS.Systems
                 }
             }
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<CameraComponent> _uninitializedComponents { get; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.CameraComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.CameraComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -277,13 +281,9 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Private Member Methods
-
-        #endregion Member Methods
+        #endregion
 
         #region Static Methods
-
-        #region Private Static Methods
         /// <summary>
         /// Performs the update logic on all <see cref="Komodo.Core.ECS.Components.CameraComponent"/> objects.
         /// </summary>
@@ -292,8 +292,8 @@ namespace Komodo.Core.ECS.Systems
         {
             component.ViewMatrix = component.CalculateViewMatrix();
         }
-        #endregion Private Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/ISystem.cs
+++ b/Komodo/Core/ECS/Systems/ISystem.cs
@@ -14,7 +14,6 @@ namespace Komodo.Core.ECS.Systems
     {
         #region Members
 
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="T"/> objects.
         /// </summary>
@@ -33,13 +32,11 @@ namespace Komodo.Core.ECS.Systems
         /// <summary>
         /// Whether or not the ISystem has called <see cref="Initialize()"/>.
         /// </summary>
-        public bool IsInitialized { get; }
-        #endregion Public Members
+        bool IsInitialized { get; }
 
-        #endregion Members
+        #endregion
 
         #region Member Methods
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the ISystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -50,7 +47,7 @@ namespace Komodo.Core.ECS.Systems
         /// <summary>
         /// Removes all <see cref="Komodo.Core.ECS.Entities.Entity"/> objects from the ISystem.
         /// </summary>
-        public void ClearEntities();
+        void ClearEntities();
 
         /// <summary>
         /// Should update the ISystem as well as all of it's <see cref="T"/> objects.
@@ -74,16 +71,15 @@ namespace Komodo.Core.ECS.Systems
         /// </summary>
         /// <param name="entityID">Unique identifier for the <see cref="Komodo.Core.ECS.Entities.Entity"/>.</param>
         /// <returns>Whether or not the <see cref="Komodo.Core.ECS.Entities.Entity"/> was removed from this ISystem's <see cref="Entities"/>. Will return false if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not present in <see cref="Entities"/>.</returns>
-        public bool RemoveEntity(Guid entityID);
+        bool RemoveEntity(Guid entityID);
 
         /// <summary>
         /// Removes a <see cref="Komodo.Core.ECS.Entities.Entity"/> from the ISystem, including all the <see cref="Komodo.Core.ECS.Entities.Entity"/>'s <see cref="Komodo.Core.ECS.Components.Component"/> objects.
         /// </summary>
         /// <param name="entityToRemove"><see cref="Komodo.Core.ECS.Entities.Entity"/> to remove.</param>
         /// <returns>Whether or not the <see cref="Komodo.Core.ECS.Entities.Entity"/> was removed from this ISystem's <see cref="Entities"/>. Will return false if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not present in <see cref="Entities"/>.</returns>
-        public bool RemoveEntity(Entity entityToRemove);
-        #endregion Public Member Methods
+        bool RemoveEntity(Entity entityToRemove);
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/PhysicsSystem.cs
+++ b/Komodo/Core/ECS/Systems/PhysicsSystem.cs
@@ -20,6 +20,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class PhysicsSystem : ISystem<PhysicsComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public PhysicsSystem(Game game)
@@ -29,11 +31,9 @@ namespace Komodo.Core.ECS.Systems
             Game = game;
             _uninitializedComponents = new Queue<PhysicsComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> objects.
         /// </summary>
@@ -53,21 +53,9 @@ namespace Komodo.Core.ECS.Systems
         /// Whether or not the PhysicsSystem has called <see cref="Initialize()"/>.
         /// </summary>
         public bool IsInitialized { get; private set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<PhysicsComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the PhysicsSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -213,9 +201,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -276,9 +268,21 @@ namespace Komodo.Core.ECS.Systems
                 HandleCollisions();
             }
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<PhysicsComponent> _uninitializedComponents { get; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.PhysicsComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -444,13 +448,9 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Protected Member Methods
-
-        #endregion Member Methods
+        #endregion
 
         #region Static Methods
-
-        #region Private Static Methods
         /// <summary>
         /// Performs an AABB AABB collision check.
         /// </summary>
@@ -713,8 +713,8 @@ namespace Komodo.Core.ECS.Systems
             float delta = (float)gameTime.ElapsedGameTime.TotalSeconds;
             body.Parent.Position += body.PositionDelta * delta;
         }
-        #endregion Private Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/Render2DSystem.cs
+++ b/Komodo/Core/ECS/Systems/Render2DSystem.cs
@@ -28,6 +28,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class Render2DSystem : ISystem<Drawable2DComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public Render2DSystem(Game game)
@@ -39,11 +41,9 @@ namespace Komodo.Core.ECS.Systems
 
             _uninitializedComponents = new Queue<Drawable2DComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// <see cref="Komodo.Core.ECS.Components.CameraComponent"/> to be used for rendering all tracked <see cref="Components"/>.
         /// </summary>
@@ -73,21 +73,9 @@ namespace Komodo.Core.ECS.Systems
         /// Texture filtering to use for 2D sprites and fonts.
         /// </summary>
         public SamplerState TextureFilter { get; set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<Drawable2DComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the Drawable2DSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -211,9 +199,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -258,9 +250,21 @@ namespace Komodo.Core.ECS.Systems
         {
             return RemoveDrawable2DComponent(componentToRemove);
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<Drawable2DComponent> _uninitializedComponents { get; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.Drawable2DComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -469,8 +473,8 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/Render3DSystem.cs
+++ b/Komodo/Core/ECS/Systems/Render3DSystem.cs
@@ -22,6 +22,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class Render3DSystem : ISystem<Drawable3DComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public Render3DSystem(Game game)
@@ -33,11 +35,9 @@ namespace Komodo.Core.ECS.Systems
 
             _uninitializedComponents = new Queue<Drawable3DComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// <see cref="Komodo.Core.ECS.Components.CameraComponent"/> to be used for rendering all tracked <see cref="Components"/>.
         /// </summary>
@@ -67,21 +67,9 @@ namespace Komodo.Core.ECS.Systems
         /// Texture filtering to use for 3D textures.
         /// </summary>
         public SamplerState TextureFilter { get; set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<Drawable3DComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the Drawable3DSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -205,9 +193,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Internal Member Methods
+        #endregion
+
+        #region Internal
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -266,9 +258,21 @@ namespace Komodo.Core.ECS.Systems
         {
             return RemoveDrawable3DComponent(componentToRemove);
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<Drawable3DComponent> _uninitializedComponents { get; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.Drawable3DComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -359,8 +363,8 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/ECS/Systems/SoundSystem.cs
+++ b/Komodo/Core/ECS/Systems/SoundSystem.cs
@@ -17,6 +17,8 @@ namespace Komodo.Core.ECS.Systems
     /// </summary>
     public class SoundSystem : ISystem<SoundComponent>
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public SoundSystem(Game game)
@@ -26,11 +28,9 @@ namespace Komodo.Core.ECS.Systems
             Game = game;
             _uninitializedComponents = new Queue<SoundComponent>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// All tracked <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects.
         /// </summary>
@@ -50,21 +50,9 @@ namespace Komodo.Core.ECS.Systems
         /// Whether or not the SoundSystem has called <see cref="Initialize()"/>.
         /// </summary>
         public bool IsInitialized { get; private set; }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects.
-        /// All <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
-        /// </summary>
-        private Queue<SoundComponent> _uninitializedComponents { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Entities.Entity"/> to the SoundSystem if the <see cref="Komodo.Core.ECS.Entities.Entity"/> is not already present.
         /// </summary>
@@ -185,10 +173,13 @@ namespace Komodo.Core.ECS.Systems
             }
             return false;
         }
-        #endregion Public Member Methods
+        #endregion
 
+        #endregion
+    
+        #region Internal
 
-        #region Internal Member Methods
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.SoundComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.SoundComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -239,9 +230,21 @@ namespace Komodo.Core.ECS.Systems
                 }
             }
         }
-        #endregion Internal Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Tracks all potentially uninitialized <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects.
+        /// All <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects will be initialized in the <see cref="Initialize"/>, <see cref="PreUpdate(GameTime)"/>, or <see cref="PostUpdate(GameTime)"/> methods.
+        /// </summary>
+        private Queue<SoundComponent> _uninitializedComponents { get; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Adds a <see cref="Komodo.Core.ECS.Components.SoundComponent"/> to relevant <see cref="Components"/>. If the <see cref="Komodo.Core.ECS.Components.SoundComponent"/> is not initialized, it will be queued for initialization.
         /// </summary>
@@ -283,13 +286,9 @@ namespace Komodo.Core.ECS.Systems
         {
             return Components.Remove(componentToRemove);
         }
-        #endregion Private Member Methods
-
-        #endregion Member Methods
+        #endregion
 
         #region Static Methods
-
-        #region Private Static Methods
         /// <summary>
         /// Performs the update logic on all <see cref="Komodo.Core.ECS.Components.SoundComponent"/> objects.
         /// </summary>
@@ -310,8 +309,8 @@ namespace Komodo.Core.ECS.Systems
 
             component._instances = instances;
         }
-        #endregion Private Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Graphics/GraphicsManager.cs
+++ b/Komodo/Core/Engine/Graphics/GraphicsManager.cs
@@ -15,6 +15,8 @@ namespace Komodo.Core.Engine.Graphics
     /// </summary>
     public class GraphicsManager
     {
+        #region Public
+
         #region Constructors
         /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
         public GraphicsManager(Game game)
@@ -22,11 +24,9 @@ namespace Komodo.Core.Engine.Graphics
             Game = game;
             GraphicsDeviceManager = new GraphicsDeviceManager(_monoGame);
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Reference to current <see cref="Komodo.Core.Game"/> instance.
         /// </summary>
@@ -118,20 +118,9 @@ namespace Komodo.Core.Engine.Graphics
                 }
             }
         }
-        #endregion Public Members
-
-        #region Private Members
-        /// <summary>
-        /// Accessor for the underlying <see cref="Komodo.Core.MonoGame"/>.
-        /// </summary>
-        private MonoGame _monoGame => Game?._monoGame;
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Applies pending changes to the <see cref="Microsoft.Xna.Framework.GraphicsDeviceManager"/>.
         /// </summary>
@@ -247,8 +236,19 @@ namespace Komodo.Core.Engine.Graphics
                 GraphicsDeviceManager.ApplyChanges();
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Accessor for the underlying <see cref="Komodo.Core.MonoGame"/>.
+        /// </summary>
+        private MonoGame _monoGame => Game?._monoGame;
+        #endregion
+
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Graphics/Model.cs
+++ b/Komodo/Core/Engine/Graphics/Model.cs
@@ -1,6 +1,7 @@
 using Komodo.Lib.Math;
 using BoundingBox = Microsoft.Xna.Framework.BoundingBox;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
+using MonoGameModel = Microsoft.Xna.Framework.Graphics.Model;
 
 namespace Komodo.Core.Engine.Graphics
 {
@@ -9,9 +10,11 @@ namespace Komodo.Core.Engine.Graphics
     /// </summary>
     public class Model
     {
+        #region Public
+
         #region Constructors
         /// <param name="monoGameModel"><see cref="Microsoft.Xna.Framework.Graphics.Model"/> data loaded in MonoGame's format.</param>
-        public Model(Microsoft.Xna.Framework.Graphics.Model monoGameModel)
+        public Model(MonoGameModel monoGameModel)
         {
             MonoGameModel = monoGameModel;
             BoundingBox = CalculateBoundingBox();
@@ -21,11 +24,9 @@ namespace Komodo.Core.Engine.Graphics
             Height = dimensions.Y;
             Width = dimensions.X;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Z dimensional extremity.
         /// </summary>
@@ -49,14 +50,14 @@ namespace Komodo.Core.Engine.Graphics
         /// <summary>
         /// Raw 3D model data.
         /// </summary>
-        public Microsoft.Xna.Framework.Graphics.Model MonoGameModel { get; private set; }
-        #endregion Public Members
+        public MonoGameModel MonoGameModel { get; private set; }
+        #endregion
 
-        #endregion Members
+        #endregion
+
+        #region Private
 
         #region Member Methods
-        
-        #region Private Member Methods
         /// <summary>
         /// Calculates the bounding box from the raw model data.
         /// </summary>
@@ -87,8 +88,8 @@ namespace Komodo.Core.Engine.Graphics
 
             return new BoundingBox(min.MonoGameVector, max.MonoGameVector);
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Graphics/Resolution.cs
+++ b/Komodo/Core/Engine/Graphics/Resolution.cs
@@ -7,6 +7,8 @@ namespace Komodo.Core.Engine.Graphics
     /// </summary>
     public readonly struct Resolution : IEquatable<Resolution>
     {
+        #region Public
+
         #region Constructors
         /// <param name="width">Width of screen.</param>
         /// <param name="height">Width of screen.</param>
@@ -15,11 +17,9 @@ namespace Komodo.Core.Engine.Graphics
             Width = width;
             Height = height;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Aspect ratio of the resolution.
         /// </summary>
@@ -34,13 +34,9 @@ namespace Komodo.Core.Engine.Graphics
         /// Width of the screen resolution.
         /// </summary>
         public int Width { get; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Compares the equality of Resolution and an arbitrary type.
         /// </summary>
@@ -73,13 +69,9 @@ namespace Komodo.Core.Engine.Graphics
         {
             return Width.GetHashCode() + Height.GetHashCode();
         }
-        #endregion Public Member Methods
-
-        #endregion Member Methods
+        #endregion
 
         #region Static Methods
-
-        #region Public Static Methods
         /// <returns>Whether or not the Resolutions are equivalent.</returns>
         public static bool operator ==(Resolution left, Resolution right)
         {
@@ -91,8 +83,8 @@ namespace Komodo.Core.Engine.Graphics
         {
             return !(left == right);
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Graphics/Texture.cs
+++ b/Komodo/Core/Engine/Graphics/Texture.cs
@@ -10,6 +10,8 @@ namespace Komodo.Core.Engine.Graphics
     /// </summary>
     public class Texture
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates a Texture from <see cref="Microsoft.Xna.Framework.Graphics.Texture2D"/> data.
@@ -65,11 +67,9 @@ namespace Komodo.Core.Engine.Graphics
             CreateMonoGameTexture(graphicsManager);
         }
 
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Height of the Texture data.
         /// </summary>
@@ -96,9 +96,24 @@ namespace Komodo.Core.Engine.Graphics
         /// Raw MonoGame <see cref="Microsoft.Xna.Framework.Graphics.Texture2D"/>.
         /// </summary>
         public Texture2D MonoGameTexture { get; private set; }
-        #endregion Public Members
+        #endregion
 
-        #region Private Members
+        #region Member Methods
+        /// <summary>
+        /// Accessor for raw <see cref="Microsoft.Xna.Framework.Color"/> data.
+        /// </summary>
+        /// <returns></returns>
+        public Color[] GetData()
+        {
+            return _data;
+        }
+        #endregion
+
+        #endregion
+        
+        #region Private
+
+        #region Members
         /// <summary>
         /// Used to store the Texture height from <see cref="Initialize"/> to be used in <see cref="CreateMonoGameTexture(GraphicsManager)"/>.
         /// </summary>
@@ -113,24 +128,9 @@ namespace Komodo.Core.Engine.Graphics
         /// Raw <see cref="Microsoft.Xna.Framework.Color"/> data.
         /// </summary>
         private Color[] _data;
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
-        /// <summary>
-        /// Accessor for raw <see cref="Microsoft.Xna.Framework.Color"/> data.
-        /// </summary>
-        /// <returns></returns>
-        public Color[] GetData()
-        {
-            return _data;
-        }
-        #endregion Public Member Methods
-
-        #region Private Member Methods
         /// <summary>
         /// 
         /// </summary>
@@ -204,8 +204,8 @@ namespace Komodo.Core.Engine.Graphics
         {
             _data = value;
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Input/InputInfo.cs
+++ b/Komodo/Core/Engine/Input/InputInfo.cs
@@ -8,6 +8,8 @@ namespace Komodo.Core.Engine.Input
     /// </summary>
     public readonly struct InputInfo : IEquatable<InputInfo>
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates InputInfo for digital inputs.
@@ -44,11 +46,9 @@ namespace Komodo.Core.Engine.Input
             State = state;
             Strength = strength;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Direction of the supplied <see cref="Komodo.Core.Engine.Input.Inputs"/>.
         /// </summary>
@@ -68,13 +68,9 @@ namespace Komodo.Core.Engine.Input
         /// Strength of the <see cref="Komodo.Core.Engine.Input.Inputs"/>.
         /// </summary>
         public float Strength { get; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         /// <summary>
         /// Compares the equality of InputInfo and an arbitrary type.
         /// </summary>
@@ -107,13 +103,9 @@ namespace Komodo.Core.Engine.Input
         {
             return Direction.GetHashCode() + Input.GetHashCode() + State.GetHashCode() + Strength.GetHashCode();
         }
-        #endregion Public Member Methods
-
-        #endregion Member Methods
+        #endregion
 
         #region Static Methods
-
-        #region Public Static Methods
         /// <returns>Whether or not the InputInfos are equivalent.</returns>
         public static bool operator ==(InputInfo left, InputInfo right)
         {
@@ -125,8 +117,8 @@ namespace Komodo.Core.Engine.Input
         {
             return !(left == right);
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Input/InputManager.cs
+++ b/Komodo/Core/Engine/Input/InputManager.cs
@@ -18,65 +18,9 @@ namespace Komodo.Core.Engine.Input
     /// </summary>
     public static class InputManager
     {
-        /// <summary>
-        /// Sets up the input maps and input device states.
-        /// </summary>
-        static InputManager()
-        {
-            _inputMaps = new Dictionary<string, List<Inputs>>[4];
-            for (int i = 0; i < _inputMaps.Length; i++)
-            {
-                _inputMaps[i] = new Dictionary<string, List<Inputs>>();
-            }
-            _gamePadStates = new GamePadState[4];
-            _previousGamePadStates = new GamePadState[4];
-            Update();
-        }
-
-        #region Static Members
-        
-        #region Private Static Members
-        /// <summary>
-        /// Current state of all 4 supported gamepads.
-        /// </summary>
-        private static GamePadState[] _gamePadStates { get; set; }
-
-        /// <summary>
-        /// State of input maps for all 4 supported players.
-        /// </summary>
-        private static Dictionary<string, List<Inputs>>[] _inputMaps { get; }
-
-        /// <summary>
-        /// Current state of 1 supported keyboard.
-        /// </summary>
-        private static KeyboardState _keyboardState { get; set; }
-
-        /// <summary>
-        /// Current state of 1 supported mouse.
-        /// </summary>
-        private static MouseState _mouseState { get; set; }
-
-        /// <summary>
-        /// Previous state of all 4 supported gamepads.
-        /// </summary>
-        private static GamePadState[] _previousGamePadStates { get; set; }
-
-        /// <summary>
-        /// Previous state of 1 supported keyboard.
-        /// </summary>
-        private static KeyboardState _previousKeyboardState { get; set; }
-
-        /// <summary>
-        /// Previous state of 1 supported mouse.
-        /// </summary>
-        private static MouseState _previousMouseState { get; set; }
-        #endregion Private Static Members
-        
-        #endregion Static Members
+        #region Public
 
         #region Static Methods
-        
-        #region Public Static Methods
         /// <summary>
         /// Adds an input mapping to the specified player.
         /// </summary>
@@ -277,9 +221,13 @@ namespace Komodo.Core.Engine.Input
         {
             Mouse.SetPosition(x, y);
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #region Internal Static Methods
+        #endregion
+
+        #region Internal
+
+        #region Static Methods
         /// <summary>
         /// Updates current and previous input states across all input devices.
         /// </summary>
@@ -298,10 +246,50 @@ namespace Komodo.Core.Engine.Input
                 _gamePadStates[i] = GamePad.GetState(playerIndex);
             }
         }
-        #endregion Internal Static Methods
+        #endregion
 
+        #endregion
 
-        #region Private Static Methods
+        #region Private
+
+        #region Static Members
+        /// <summary>
+        /// Current state of all 4 supported gamepads.
+        /// </summary>
+        private static GamePadState[] _gamePadStates { get; set; }
+
+        /// <summary>
+        /// State of input maps for all 4 supported players.
+        /// </summary>
+        private static Dictionary<string, List<Inputs>>[] _inputMaps { get; }
+
+        /// <summary>
+        /// Current state of 1 supported keyboard.
+        /// </summary>
+        private static KeyboardState _keyboardState { get; set; }
+
+        /// <summary>
+        /// Current state of 1 supported mouse.
+        /// </summary>
+        private static MouseState _mouseState { get; set; }
+
+        /// <summary>
+        /// Previous state of all 4 supported gamepads.
+        /// </summary>
+        private static GamePadState[] _previousGamePadStates { get; set; }
+
+        /// <summary>
+        /// Previous state of 1 supported keyboard.
+        /// </summary>
+        private static KeyboardState _previousKeyboardState { get; set; }
+
+        /// <summary>
+        /// Previous state of 1 supported mouse.
+        /// </summary>
+        private static MouseState _previousMouseState { get; set; }
+        #endregion
+
+        #region Static Methods
         /// <summary>
         /// Retrives <see cref="Komodo.Core.Engine.Input.InputInfo"/> for the given <see cref="Komodo.Core.Engine.Input.Inputs"/>.
         /// </summary>
@@ -386,8 +374,25 @@ namespace Komodo.Core.Engine.Input
                 _ => PlayerIndex.One,
             };
         }
-        #endregion Private Static Methods
-        
-        #endregion Static Methods
+        #endregion
+
+        #endregion
+
+        #region Static Constructor
+        /// <summary>
+        /// Sets up the input maps and input device states.
+        /// </summary>
+        static InputManager()
+        {
+            _inputMaps = new Dictionary<string, List<Inputs>>[4];
+            for (int i = 0; i < _inputMaps.Length; i++)
+            {
+                _inputMaps[i] = new Dictionary<string, List<Inputs>>();
+            }
+            _gamePadStates = new GamePadState[4];
+            _previousGamePadStates = new GamePadState[4];
+            Update();
+        }
+        #endregion
     }
 }

--- a/Komodo/Core/Engine/Input/InputMapper.cs
+++ b/Komodo/Core/Engine/Input/InputMapper.cs
@@ -10,15 +10,15 @@ namespace Komodo.Core.Engine.Input
     /// </summary>
     internal static class InputMapper
     {
-        #region Static Methods
+        #region Internal
 
-        #region Public Static Methods
+        #region Static Methods
         /// <summary>
         /// Converts <see cref="Microsoft.Xna.Framework.Input.Buttons"/> to <see cref="Komodo.Core.Engine.Input.Inputs"/>.
         /// </summary>
         /// <param name="button">MonoGame button.</param>
         /// <returns>Converted MonoGame button.</returns>
-        public static Inputs ToInputs(Buttons button)
+        internal static Inputs ToInputs(Buttons button)
         {
             return button switch
             {
@@ -48,7 +48,7 @@ namespace Komodo.Core.Engine.Input
         /// </summary>
         /// <param name="key">MonoGame key.</param>
         /// <returns>Converted MonoGame key.</returns>
-        public static Inputs ToInputs(Keys key)
+        internal static Inputs ToInputs(Keys key)
         {
             return key switch
             {
@@ -116,7 +116,7 @@ namespace Komodo.Core.Engine.Input
         /// </summary>
         /// <param name="buttonState">MonoGame button state.</param>
         /// <returns>Converted MonoGame button state.</returns>
-        public static InputState ToInputState(ButtonState buttonState)
+        internal static InputState ToInputState(ButtonState buttonState)
         {
             return buttonState switch
             {
@@ -131,7 +131,7 @@ namespace Komodo.Core.Engine.Input
         /// </summary>
         /// <param name="keyState">MonoGame key state.</param>
         /// <returns>Converted MonoGame key state.</returns>
-        public static InputState ToInputState(KeyState keyState)
+        internal static InputState ToInputState(KeyState keyState)
         {
             return keyState switch
             {
@@ -146,7 +146,7 @@ namespace Komodo.Core.Engine.Input
         /// </summary>
         /// <param name="input">Komodo input.</param>
         /// <returns>Converted Komodo input as <see cref="Microsoft.Xna.Framework.Input.Buttons"/>.</returns>
-        public static Buttons? ToMonoGameButton(Inputs input)
+        internal static Buttons? ToMonoGameButton(Inputs input)
         {
             return input switch
             {
@@ -176,7 +176,7 @@ namespace Komodo.Core.Engine.Input
         /// </summary>
         /// <param name="input">Komodo input.</param>
         /// <returns>Converted Komodo input as <see cref="Microsoft.Xna.Framework.Input.Keys"/>.</returns>
-        public static Keys? ToMonoGameKey(Inputs input)
+        internal static Keys? ToMonoGameKey(Inputs input)
         {
             return input switch
             {
@@ -238,8 +238,8 @@ namespace Komodo.Core.Engine.Input
                 _ => null,
             };
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Game.cs
+++ b/Komodo/Core/Game.cs
@@ -20,6 +20,8 @@ namespace Komodo.Core
     /// </summary>
     public class Game : IDisposable
     {
+        #region Public
+
         #region Constructors
         /// <summary>
         /// Creates the Game instance, instantiating the underlying <see cref="Komodo.Core.MonoGame"/> instance, <see cref="Komodo.Core.Engine.Graphics.GraphicsManager"/>, and <see cref="Komodo.Core.ECS.Systems.ISystem"/> objects.
@@ -41,11 +43,9 @@ namespace Komodo.Core
             Render3DSystems = new List<Render3DSystem>();
             SoundSystem = new SoundSystem(this);
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Manages all <see cref="Komodo.Core.ECS.Components.BehaviorComponent"/> objects.
         /// </summary>
@@ -121,31 +121,9 @@ namespace Komodo.Core
                 }
             }
         }
-        #endregion Public Members
-        
-        #region Internal Members
-        /// <summary>
-        /// Provides access to MonoGame APIs.
-        /// </summary>
-        internal readonly MonoGame _monoGame;
-        #endregion Internal Members
-
-        #endregion Members
-
-        #region Static Members
-
-        #region Public Static Members
-        /// <summary>
-        /// Provides access to the content files compiled by the MonoGame Content Pipeline (Releases: https://github.com/MonoGame/MonoGame/releases).
-        /// </summary>
-        public static ContentManager Content { get; private set; }
-        #endregion Public Static Members
-
-        #endregion Static Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
 
         #region Add event handlers
         /// <summary>
@@ -346,7 +324,7 @@ namespace Komodo.Core
         {
             _monoGame.Window.ClientSizeChanged += handler;
         }
-        #endregion Add event handlers
+        #endregion
 
         #region Remove event handlers
         /// <summary>
@@ -420,7 +398,7 @@ namespace Komodo.Core
         {
             _monoGame.Window.ClientSizeChanged -= handler;
         }
-        #endregion Remove event handlers
+        #endregion
 
         /// <summary>
         /// Creates and begins tracking a new <see cref="Komodo.Core.ECS.Systems.PhysicsSystem"/>.
@@ -584,9 +562,27 @@ namespace Komodo.Core
                 system.PostUpdate(gameTime);
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #region Static Members
+        /// <summary>
+        /// Provides access to the content files compiled by the MonoGame Content Pipeline (Releases: https://github.com/MonoGame/MonoGame/releases).
+        /// </summary>
+        public static ContentManager Content { get; private set; }
+        #endregion
+
+        #endregion
+
+        #region Internal
+
+        #region Internal Members
+        /// <summary>
+        /// Provides access to MonoGame APIs.
+        /// </summary>
+        internal readonly MonoGame _monoGame;
+        #endregion
+
+        #endregion
 
         #region IDisposable Support
         /// <summary>

--- a/Komodo/Core/MonoGame.cs
+++ b/Komodo/Core/MonoGame.cs
@@ -7,32 +7,25 @@ namespace Komodo.Core
     /// </summary>
     internal class MonoGame : Microsoft.Xna.Framework.Game
     {
+        #region Internal
+
         #region Constructors
         /// <summary>
         /// Defines the root directory of content files.
         /// </summary>
         /// /// <param name="game">Reference to current <see cref="Komodo.Core.Game"/> instance.</param>
-        public MonoGame(Game game)
+        internal MonoGame(Game game)
         {
             _game = game;
             Content.RootDirectory = "Content/MonoGame";
         }
-        #endregion Constructors
+        #endregion
 
-        #region Members
+        #endregion
 
-        #region Private Members
-        /// <summary>
-        /// Reference to current <see cref="Komodo.Core.Game"/> instance.
-        /// </summary>
-        private Game _game { get; }
-        #endregion Private Members
-
-        #endregion Members
+        #region Protected
 
         #region Member Methods
-
-        #region Protected Member Methods
         /// <summary>
         /// Passthrough function to <see cref="Komodo.Core.Game.Draw(GameTime)"/>.
         /// </summary>
@@ -71,8 +64,19 @@ namespace Komodo.Core
 
             base.Update(gameTime);
         }
-        #endregion Protected Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        /// <summary>
+        /// Reference to current <see cref="Komodo.Core.Game"/> instance.
+        /// </summary>
+        private Game _game { get; }
+        #endregion
+
+        #endregion
     }
 }

--- a/Komodo/Core/Physics/Box.cs
+++ b/Komodo/Core/Physics/Box.cs
@@ -9,6 +9,8 @@ namespace Komodo.Core.Physics
     /// </summary>
     public class Box : IPhysicsShape
     {
+        #region Public
+        
         #region Constructors
         public Box(float width, float height, float depth, float mass)
         {
@@ -25,11 +27,9 @@ namespace Komodo.Core.Physics
             Depth = dimensions.Z;
             Mass = mass;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Depth of the Box.
         /// </summary>
@@ -113,27 +113,27 @@ namespace Komodo.Core.Physics
                 UpdateMomentOfInertia();
             }
         }
-        #endregion Public Members
-
-        #region Private Members
-        private float _depth { get; set; }
-        private float _height { get; set; }
-        private float _mass { get; set; }
-        private float _width { get; set; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public IPhysicsShape GetScaledShape(Vector3 scale)
         {
             return new Box(Width * scale.X, Height * scale.Y, Depth * scale.Z, Mass);
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        private float _depth { get; set; }
+        private float _height { get; set; }
+        private float _mass { get; set; }
+        private float _width { get; set; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Updates the moment of intertia. Called whenever relevant fields have been updated.
         /// </summary>
@@ -144,8 +144,8 @@ namespace Komodo.Core.Physics
             float z = Mass * (Width * Width + Height * Height) / 12f;
             MomentOfInertia = new Vector3(x, y, z);
         }
-        #endregion Private Member Methods
-        
-        #endregion Member Methods
+        #endregion
+
+        #endregion
     }
 }

--- a/Komodo/Core/Physics/Collision.cs
+++ b/Komodo/Core/Physics/Collision.cs
@@ -9,6 +9,8 @@ namespace Komodo.Core.Physics
     /// </summary>
     public class Collision
     {
+        #region Public
+
         #region Constructors
         public Collision(bool isColliding, Vector3 normal, float penetrationDepth)
         {
@@ -17,11 +19,9 @@ namespace Komodo.Core.Physics
             PenetrationDepth = penetrationDepth;
             _isResolved = false;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Correction vector for the collision. Adding this to the affected object's position will separate the collision.
         /// </summary>
@@ -41,12 +41,16 @@ namespace Komodo.Core.Physics
         /// Depth of penetration of the collision.
         /// </summary>
         public readonly float PenetrationDepth;
-        #endregion Public Members
+        #endregion
 
-        #region Internal Members
+        #endregion
+
+        #region Internal
+
+        #region Members
         internal bool _isResolved { get; set; }
-        #endregion Internal Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Core/Physics/IPhysicsShape.cs
+++ b/Komodo/Core/Physics/IPhysicsShape.cs
@@ -8,8 +8,6 @@ namespace Komodo.Core.Physics
     public interface IPhysicsShape
     {
         #region Members
-
-        #region Public Members
         /// <summary>
         /// Mass of the given shape.
         /// </summary>
@@ -18,16 +16,10 @@ namespace Komodo.Core.Physics
         /// Moment of inertia for the given shape. This is usually a calculated value based on mass, location of vertices, etc.
         /// </summary>
         Vector3 MomentOfInertia { get; }
-        #endregion Public Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         IPhysicsShape GetScaledShape(Vector3 scale);
-        #endregion Public Member Methods
-
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Core/Physics/PhysicsMaterial.cs
+++ b/Komodo/Core/Physics/PhysicsMaterial.cs
@@ -9,6 +9,8 @@ namespace Komodo.Core.Physics
     /// </summary>
     public class PhysicsMaterial
     {
+        #region Public
+        
         #region Constructors
         /// <summary>
         /// Creates a new physics material. Physics material names are unique identifiers.
@@ -36,11 +38,9 @@ namespace Komodo.Core.Physics
             _materials = new Dictionary<string, PhysicsMaterial>();
             _ = new PhysicsMaterial("default");
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         /// <summary>
         /// <see cref="AngularDamping"/> defines how an object's angular veloctity is reduced over time with no interaction from other physics objects.
         /// </summary>
@@ -168,30 +168,9 @@ namespace Komodo.Core.Physics
                 }
             }
         }
-        #endregion Public Members
-
-        #region Internal Members
-        internal float _angularDamping { get; set; }
-        internal float _angularDampingLimit { get; set; }
-        internal float _friction { get; set; }
-        internal float _linearDamping { get; set; }
-        internal float _linearDampingLimit { get; set; }
-        internal float _restitution { get; set; }
-        #endregion Internal Members
-
-        #endregion Members
-
-        #region Static Members
-
-        #region Private Static Members
-        private static Dictionary<string, PhysicsMaterial> _materials { get; set; }
-        #endregion Private Static Members
-
-        #endregion Static Members
+        #endregion
 
         #region Static Member Methods
-
-        #region Public Static Member Methods
         /// <summary>
         /// Provides the PhysicsMaterial instance for the given name.
         /// </summary>
@@ -208,8 +187,29 @@ namespace Komodo.Core.Physics
 
             return material;
         }
-        #endregion Public Static Member Methods
+        #endregion
 
-        #endregion Static Member Methods
+        #endregion
+        
+        #region Internal
+
+        #region Members
+        internal float _angularDamping { get; set; }
+        internal float _angularDampingLimit { get; set; }
+        internal float _friction { get; set; }
+        internal float _linearDamping { get; set; }
+        internal float _linearDampingLimit { get; set; }
+        internal float _restitution { get; set; }
+        #endregion
+
+        #endregion
+
+        #region Private
+
+        #region Static Members
+        private static Dictionary<string, PhysicsMaterial> _materials { get; set; }
+        #endregion
+
+        #endregion
     }
 }

--- a/Komodo/Core/Physics/Sphere.cs
+++ b/Komodo/Core/Physics/Sphere.cs
@@ -7,6 +7,8 @@ namespace Komodo.Core.Physics
     /// </summary>
     public class Sphere : IPhysicsShape
     {
+        #region Public
+
         #region Constructors
         public Sphere(float radius, float mass)
         {
@@ -14,10 +16,9 @@ namespace Komodo.Core.Physics
             Mass = mass;
         }
 
-        #endregion Constructors
-        #region Members
+        #endregion
 
-        #region Public Members
+        #region Members
         /// <summary>
         /// Radius of the Sphere.
         /// </summary>
@@ -57,25 +58,25 @@ namespace Komodo.Core.Physics
         /// Moment of inertia for the Sphere
         /// </summary>
         public Vector3 MomentOfInertia { get; private set; }
-        #endregion Public Members
-
-        #region Private Members
-        private float _mass { get; set; }
-        private float _radius { get; set; }
-        #endregion Private Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public IPhysicsShape GetScaledShape(Vector3 scale)
         {
             return new Sphere(Radius * scale.X, Mass);
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Private Member Methods
+        #endregion
+
+        #region Private
+
+        #region Members
+        private float _mass { get; set; }
+        private float _radius { get; set; }
+        #endregion
+
+        #region Member Methods
         /// <summary>
         /// Updates the moment of intertia. Called whenever relevant fields have been updated.
         /// </summary>
@@ -84,8 +85,8 @@ namespace Komodo.Core.Physics
             float moment = Mass * Radius * Radius * 0.4f;
             MomentOfInertia = new Vector3(moment, moment, moment);
         }
-        #endregion Private Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Compression/Brotli.cs
+++ b/Komodo/Lib/Compression/Brotli.cs
@@ -6,10 +6,9 @@ namespace Komodo.Lib.Compression
 {
     public static class Brotli
     {
+        #region Public
 
         #region Static Methods
-
-        #region Public Static Methods
         public static byte[] Compress(string data) => Compress(Encoding.ASCII.GetBytes(data));
         public static byte[] Compress(byte[] data)
         {
@@ -39,8 +38,8 @@ namespace Komodo.Lib.Compression
             return decompressedStream.ToArray();
         }
         
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Compression/GZIP.cs
+++ b/Komodo/Lib/Compression/GZIP.cs
@@ -6,10 +6,9 @@ namespace Komodo.Lib.Compression
 {
     public static class GZIP
     {
+        #region Public
 
         #region Static Methods
-
-        #region Public Static Methods
         public static byte[] Compress(string data) => Compress(Encoding.ASCII.GetBytes(data));
         public static byte[] Compress(byte[] data)
         {
@@ -39,8 +38,8 @@ namespace Komodo.Lib.Compression
             return decompressedStream.ToArray();
         }
         
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Math/Vector2.cs
+++ b/Komodo/Lib/Math/Vector2.cs
@@ -8,6 +8,8 @@ namespace Komodo.Lib.Math
 {
     public readonly struct Vector2 : IEquatable<Vector2>
     {
+        #region Public
+
         #region Constructors
         public Vector2(MonoGameVector2 vector) : this(vector.X, vector.Y)
         {
@@ -21,11 +23,9 @@ namespace Komodo.Lib.Math
         {
             MonoGameVector = new MonoGameVector2(x, y);
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public MonoGameVector2 MonoGameVector { get; }
         public float X
         {
@@ -59,27 +59,11 @@ namespace Komodo.Lib.Math
                 return new Vector2(Y, X);
             }
         }
-        #endregion Swizzling
-        #endregion Public Members
-
-        #endregion Members
-
-        #region Static Members
-
-        #region Public Static Members
-        public static Vector2 One => new Vector2(1f, 1f);
-        public static Vector2 Down => new Vector2(0f, -1f);
-        public static Vector2 Left => new Vector2(-1f, 0f);
-        public static Vector2 Right => new Vector2(1f, 0f);
-        public static Vector2 Up => new Vector2(0f, 1f);
-        public static Vector2 Zero => new Vector2();
-        #endregion Public Static Members
-
-        #endregion Static Members
+        #endregion
+        
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override bool Equals(object obj)
         {
             if (obj is Vector2 other)
@@ -101,13 +85,18 @@ namespace Komodo.Lib.Math
         {
             return MonoGameVector.Length();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #region Static Members
+        public static Vector2 One => new Vector2(1f, 1f);
+        public static Vector2 Down => new Vector2(0f, -1f);
+        public static Vector2 Left => new Vector2(-1f, 0f);
+        public static Vector2 Right => new Vector2(1f, 0f);
+        public static Vector2 Up => new Vector2(0f, 1f);
+        public static Vector2 Zero => new Vector2();
+        #endregion
 
         #region Static Methods
-
-        #region Public Static Methods
         public static Vector2 operator +(Vector2 vector) => vector;
         public static Vector2 operator -(Vector2 vector) => new Vector2(-vector.X, -vector.Y);
 
@@ -213,8 +202,8 @@ namespace Komodo.Lib.Math
             var reflection = MonoGameVector2.Reflect(vectorToReflect.MonoGameVector, normal.MonoGameVector);
             return new Vector2(reflection);
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Math/Vector3.cs
+++ b/Komodo/Lib/Math/Vector3.cs
@@ -8,6 +8,8 @@ namespace Komodo.Lib.Math
 {
     public readonly struct Vector3 : IEquatable<Vector3>
     {
+        #region Public
+
         #region Constructors
         public Vector3(MonoGameVector3 vector) : this(vector.X, vector.Y, vector.Z)
         {
@@ -21,9 +23,7 @@ namespace Komodo.Lib.Math
         {
             MonoGameVector = new MonoGameVector3(x, y, z);
         }
-        #endregion Constructors
-
-        #region Members
+        #endregion
 
         #region Public Members
         public MonoGameVector3 MonoGameVector { get; }
@@ -147,38 +147,11 @@ namespace Komodo.Lib.Math
                 return new Vector3(Z, Y, X);
             }
         }
-        #endregion Swizzling
+        #endregion
 
-        #endregion Public Members
-
-        #endregion Members
-
-        #region Static Members
-
-        #region Public Static Members
-        public static Vector3 One => new Vector3(1f, 1f, 1f);
-        public static Vector3 Zero => new Vector3();
-        public static Vector3 Up => new Vector3(0f, 1f, 0f);
-        public static Vector3 Down => -Up;
-        public static Vector3 Right => new Vector3(1f, 0f, 0f);
-        public static Vector3 Left => -Right;
-        public static Vector3 Back => new Vector3(0f, 0f, 1f);
-        public static Vector3 Forward => -Back;
-        public static Vector3 Max(Vector3 left, Vector3 right)
-        {
-            return new Vector3(MonoGameVector3.Max(left.MonoGameVector, right.MonoGameVector));
-        }
-        public static Vector3 Min(Vector3 left, Vector3 right)
-        {
-            return new Vector3(MonoGameVector3.Min(left.MonoGameVector, right.MonoGameVector));
-        }
-        #endregion Public Static Members
-
-        #endregion Static Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public override bool Equals(object obj)
         {
             if (obj is Vector3 other)
@@ -200,13 +173,28 @@ namespace Komodo.Lib.Math
         {
             return MonoGameVector.Length();
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #region Static Members
+        public static Vector3 One => new Vector3(1f, 1f, 1f);
+        public static Vector3 Zero => new Vector3();
+        public static Vector3 Up => new Vector3(0f, 1f, 0f);
+        public static Vector3 Down => -Up;
+        public static Vector3 Right => new Vector3(1f, 0f, 0f);
+        public static Vector3 Left => -Right;
+        public static Vector3 Back => new Vector3(0f, 0f, 1f);
+        public static Vector3 Forward => -Back;
+        public static Vector3 Max(Vector3 left, Vector3 right)
+        {
+            return new Vector3(MonoGameVector3.Max(left.MonoGameVector, right.MonoGameVector));
+        }
+        public static Vector3 Min(Vector3 left, Vector3 right)
+        {
+            return new Vector3(MonoGameVector3.Min(left.MonoGameVector, right.MonoGameVector));
+        }
+        #endregion
 
         #region Static Methods
-
-        #region Public Static Methods
         public static Vector3 operator +(Vector3 vector) => vector;
         public static Vector3 operator -(Vector3 vector) => new Vector3(-vector.X, -vector.Y, -vector.Z);
 
@@ -327,8 +315,8 @@ namespace Komodo.Lib.Math
             var reflection = MonoGameVector3.Reflect(vectorToReflect.MonoGameVector, normal.MonoGameVector);
             return new Vector3(reflection);
         }
-        #endregion Public Static Methods
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Network/Client.cs
+++ b/Komodo/Lib/Network/Client.cs
@@ -12,6 +12,8 @@ namespace Komodo.Lib.Network
 {
     public class Client
     {
+        #region Public
+
         #region Constructors
         public Client(string serverName, int port, SocketAsyncEventArgs socketArgs = null)
         {
@@ -32,25 +34,14 @@ namespace Komodo.Lib.Network
             _transactions = new ConcurrentDictionary<Guid, Transaction>();
             _socketArguments = socketArgs ?? new SocketAsyncEventArgs();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public IPAddress IP;
         public int Port { get; set; }
-        #endregion Public Members
-
-        #region Protected Members
-        protected ConcurrentDictionary<Guid, Transaction> _transactions { get; set; }
-        protected SocketAsyncEventArgs _socketArguments { get; set; }
-        #endregion Protected Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public Transaction Send<T>(T data, string endpoint) => SendAsync(data, endpoint).Result;
         public Transaction Send(string data, string endpoint) => SendAsync(data, endpoint).Result;
         public async Task<Transaction> SendAsync<T>(T data, string endpoint) => await SendAsync(JsonSerializer.Serialize<T>(data), endpoint);
@@ -102,16 +93,17 @@ namespace Komodo.Lib.Network
             _transactions[transaction.Id] = transaction;
             return transaction;
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #endregion Member Methods
+        #endregion
 
-        #region Static Methods
+        #region Protected
 
-        #region Protected Static Methods
-        
-        #endregion Protected Static Methods
+        #region Members
+        protected ConcurrentDictionary<Guid, Transaction> _transactions { get; set; }
+        protected SocketAsyncEventArgs _socketArguments { get; set; }
+        #endregion
 
-        #endregion Static Methods
+        #endregion
     }
 }

--- a/Komodo/Lib/Network/Message.cs
+++ b/Komodo/Lib/Network/Message.cs
@@ -4,6 +4,8 @@ namespace Komodo.Lib.Network
 {
     public class Message
     {
+        #region Public
+
         #region Constructors
         public Message()
         {
@@ -19,17 +21,15 @@ namespace Komodo.Lib.Network
             Id = Guid.NewGuid();
             TransactionId = Guid.Empty;
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public string Data { get; set; }
         public string Endpoint { get; set; }
         public Guid Id { get; set; }
         public Guid TransactionId { get; set; }
-        #endregion Public Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Komodo/Lib/Network/Transaction.cs
+++ b/Komodo/Lib/Network/Transaction.cs
@@ -4,16 +4,16 @@ namespace Komodo.Lib.Network
 {
     public sealed class Transaction
     {
+        #region Public
+
         #region Constructors
         public Transaction() 
         {
             Id = Guid.NewGuid();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public readonly Guid Id;
         public Message Request
         {
@@ -45,13 +45,17 @@ namespace Komodo.Lib.Network
                 }
             }
         }
-        #endregion Public Members
+        #endregion
 
-        #region Private Members
+        #endregion
+
+        #region Private
+
+        #region Members
         private Message _request;
         private Message _response;
-        #endregion Private Members
+        #endregion
 
-        #endregion Members
+        #endregion
     }
 }

--- a/Server/TCPServer.cs
+++ b/Server/TCPServer.cs
@@ -14,29 +14,21 @@ namespace Server
 {  
     public class TCPServer
     {
+        #region Public
+
         #region Constructors
         public TCPServer(int port)
         {
             Port = port;
             _routes = new ConcurrentDictionary<string, Action<Message>>();
         }
-        #endregion Constructors
+        #endregion
 
         #region Members
-
-        #region Public Members
         public int Port { get; set; }
-        #endregion Public Members
-
-        #region Protected Members
-        public ConcurrentDictionary<string, Action<Message>> _routes;
-        #endregion Protected Members
-
-        #endregion Members
+        #endregion
 
         #region Member Methods
-
-        #region Public Member Methods
         public void RegisterAction([NotNull] string endpoint, [NotNull] Action<Message> messageHandler)
         {
             _routes[endpoint] = messageHandler;
@@ -68,9 +60,17 @@ namespace Server
                 cancellation.Cancel();
             }
         }
-        #endregion Public Member Methods
+        #endregion
 
-        #region Protected Member Methods
+        #endregion
+
+        #region Protected
+
+        #region Members
+        public ConcurrentDictionary<string, Action<Message>> _routes;
+        #endregion
+
+        #region Member Methods
         protected async void HandleConnection([NotNull] TcpClient client)
         {
             await Task.Yield();
@@ -115,15 +115,8 @@ namespace Server
             }
         }
 
-        #endregion Protected Member Methods
+        #endregion
 
-        #endregion Member Methods
-
-        #region Static Methods
-
-        #region Protected Static Methods
-        #endregion Protected Static Methods
-
-        #endregion Static Methods
+        #endregion
     }
 }


### PR DESCRIPTION
Closes #131 
Regions are now broken up as such:

Access Level
    -> Constructors
    -> Members
    -> Member Methods
    -> Static Members
    -> Static Methods
Disposable Support
Destructors